### PR TITLE
Configure GitHub Pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,2 @@
+title: GxP Blueprint SOPs
+theme: jekyll-theme-slate

--- a/docs/csv/index.md
+++ b/docs/csv/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Computerised System Validation SOP
+---
+
+{% include_relative _main.md %}

--- a/docs/data-integrity/index.md
+++ b/docs/data-integrity/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Data Integrity SOP
+---
+
+{% include_relative _main.md %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: GxP SOPs
+---
+
+This site hosts the Standard Operating Procedures.
+
+- [Computerised System Validation](csv/)
+- [Data Integrity](data-integrity/)


### PR DESCRIPTION
## Summary
- add minimal `jekyll-theme-slate` configuration
- add index page with SOP links
- render each SOP using Jekyll includes

## Testing
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b28f9c80832590c9fbf2936816ac